### PR TITLE
[PEA-110] Allow to set is_active parameter.

### DIFF
--- a/openedx_external_enrollments/external_enrollments/edx_enterprise_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/edx_enterprise_external_enrollment.py
@@ -58,7 +58,7 @@ class EdxEnterpriseExternalEnrollment(BaseExternalEnrollment):
                 data.get("course_mode"),
             ),
             "user_email": data.get("user_email"),
-            "is_active": True,
+            "is_active": data.get("is_active", True),
         }]
 
     def _get_enrollment_url(self, course_settings):

--- a/openedx_external_enrollments/external_enrollments/edx_instance_external_enrollment.py
+++ b/openedx_external_enrollments/external_enrollments/edx_instance_external_enrollment.py
@@ -30,7 +30,7 @@ class EdxInstanceExternalEnrollment(BaseExternalEnrollment):
         user, _ = get_user(email=data.get("user_email"))
         return {
             "user": user.username,
-            "is_active": True,
+            "is_active": data.get("is_active", True),
             "mode": course_settings.get(
                 "external_enrollment_mode_override",
                 data.get("course_mode")

--- a/openedx_external_enrollments/tests/external_enrollments/tests_edx_enterprise_external_enrollment.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_edx_enterprise_external_enrollment.py
@@ -51,6 +51,14 @@ class EdxEnterpriseExternalEnrollmentTest(TestCase):
             [expected_data],
         )
 
+        data['is_active'] = False
+        expected_data['is_active'] = False
+
+        self.assertEqual(
+            self.base._get_enrollment_data(data, course_settings),  # pylint: disable=protected-access
+            [expected_data],
+        )
+
         expected_data = {key: None for key in expected_data}
         expected_data['is_active'] = True
 

--- a/openedx_external_enrollments/tests/external_enrollments/tests_edx_instance_external_enrollment.py
+++ b/openedx_external_enrollments/tests/external_enrollments/tests_edx_instance_external_enrollment.py
@@ -52,7 +52,16 @@ class EdxInstanceExternalEnrollmentTest(TestCase):
             expected_data,
         )
 
+        data['is_active'] = False
+        expected_data['is_active'] = False
+
+        self.assertEqual(
+            self.base._get_enrollment_data(data, course_settings),  # pylint: disable=protected-access
+            expected_data,
+        )
+
         expected_data['mode'] = None
+        expected_data['is_active'] = True
         expected_data['course_details']['course_id'] = None
 
         self.assertEqual(


### PR DESCRIPTION
## Description
Allow to set the is_active parameter by using the data information.